### PR TITLE
Expose logging config for calico cni

### DIFF
--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -203,11 +203,11 @@ type CNILogging struct {
 
 	// Default: 30 (days)
 	// +optional
-	LogFileMaxAgeDays *int `json:"logFileMaxAge,omitempty"`
+	LogFileMaxAgeDays *uint32 `json:"logFileMaxAgeDays,omitempty"`
 
 	// Default: 10
 	// +optional
-	LogFileMaxCount *int `json:"logFileMaxCount,omitempty"`
+	LogFileMaxCount *uint32 `json:"logFileMaxCount,omitempty"`
 }
 
 type FIPSMode string

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -822,12 +822,12 @@ func (in *CNILogging) DeepCopyInto(out *CNILogging) {
 	}
 	if in.LogFileMaxAgeDays != nil {
 		in, out := &in.LogFileMaxAgeDays, &out.LogFileMaxAgeDays
-		*out = new(int)
+		*out = new(uint32)
 		**out = **in
 	}
 	if in.LogFileMaxCount != nil {
 		in, out := &in.LogFileMaxCount, &out.LogFileMaxCount
-		*out = new(int)
+		*out = new(uint32)
 		**out = **in
 	}
 }

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -710,13 +710,13 @@ func fillDefaults(instance *operator.Installation) error {
 
 		// set LogFileMaxCount default to 10
 		if instance.Spec.Logging.CNILogging.LogFileMaxCount == nil {
-			instance.Spec.Logging.CNILogging.LogFileMaxCount = new(int)
+			instance.Spec.Logging.CNILogging.LogFileMaxCount = new(uint32)
 			*instance.Spec.Logging.CNILogging.LogFileMaxCount = 10
 		}
 
 		// set LogFileMaxAge default to 30 days
 		if instance.Spec.Logging.CNILogging.LogFileMaxAgeDays == nil {
-			instance.Spec.Logging.CNILogging.LogFileMaxAgeDays = new(int)
+			instance.Spec.Logging.CNILogging.LogFileMaxAgeDays = new(uint32)
 			*instance.Spec.Logging.CNILogging.LogFileMaxAgeDays = 30
 		}
 

--- a/pkg/controller/installation/defaults_test.go
+++ b/pkg/controller/installation/defaults_test.go
@@ -57,8 +57,8 @@ var _ = Describe("Defaulting logic tests", func() {
 		Expect(*instance.Spec.NonPrivileged).To(Equal(operator.NonPrivilegedDisabled))
 		Expect(instance.Spec.KubeletVolumePluginPath).To(Equal(filepath.Clean("/var/lib/kubelet")))
 		Expect(*instance.Spec.Logging.CNILogging.LogSeverity).To(Equal(operator.LogLevelInfo))
-		Expect(*instance.Spec.Logging.CNILogging.LogFileMaxCount).To(Equal(10))
-		Expect(*instance.Spec.Logging.CNILogging.LogFileMaxAgeDays).To(Equal(30))
+		Expect(*instance.Spec.Logging.CNILogging.LogFileMaxCount).To(Equal(uint32(10)))
+		Expect(*instance.Spec.Logging.CNILogging.LogFileMaxAgeDays).To(Equal(uint32(30)))
 		Expect(*instance.Spec.Logging.CNILogging.LogFileMaxSize).To(Equal(resource.MustParse("100Mi")))
 
 	})
@@ -96,8 +96,8 @@ var _ = Describe("Defaulting logic tests", func() {
 		var oneTwoThree int32 = 123
 		var one intstr.IntOrString = intstr.FromInt(1)
 		var replicas int32 = 3
-		var logFileMaxCount = 5
-		var logFileMaxAgeDays = 10
+		var logFileMaxCount uint32 = 5
+		var logFileMaxAgeDays uint32 = 10
 		var logFileMaxSize = resource.MustParse("50Mi")
 		var logSeverity = operator.LogLevelError
 
@@ -186,8 +186,8 @@ var _ = Describe("Defaulting logic tests", func() {
 		var twentySeven int32 = 27
 		var one intstr.IntOrString = intstr.FromInt(1)
 		var replicas int32 = 3
-		var logFileMaxCount = 5
-		var logFileMaxAgeDays = 10
+		var logFileMaxCount uint32 = 5
+		var logFileMaxAgeDays uint32 = 10
 		var logFileMaxSize = resource.MustParse("50Mi")
 		var logSeverity = operator.LogLevelError
 
@@ -509,8 +509,8 @@ var _ = Describe("Defaulting logic tests", func() {
 		}
 		Expect(fillDefaults(instance)).NotTo(HaveOccurred())
 		Expect(*instance.Spec.Logging.CNILogging.LogSeverity).To(Equal(operator.LogLevelInfo))
-		Expect(*instance.Spec.Logging.CNILogging.LogFileMaxCount).To(Equal(10))
-		Expect(*instance.Spec.Logging.CNILogging.LogFileMaxAgeDays).To(Equal(30))
+		Expect(*instance.Spec.Logging.CNILogging.LogFileMaxCount).To(Equal(uint32(10)))
+		Expect(*instance.Spec.Logging.CNILogging.LogFileMaxAgeDays).To(Equal(uint32(30)))
 		Expect(*instance.Spec.Logging.CNILogging.LogFileMaxSize).To(Equal(resource.MustParse("100Mi")))
 		Expect(validateCustomResource(instance)).NotTo(HaveOccurred())
 	})

--- a/pkg/controller/installation/validation.go
+++ b/pkg/controller/installation/validation.go
@@ -436,6 +436,12 @@ func validateCustomResource(instance *operatorv1.Installation) error {
 		}
 	}
 
+	// Verify CNILogging to not exist for non-calico cni
+	if cni := instance.Spec.CNI.Type; cni != operatorv1.PluginCalico {
+		if instance.Spec.Logging != nil && instance.Spec.Logging.CNILogging != nil {
+			return fmt.Errorf("Installation spec.Logging.cniLogging is not valid and should not be provided when spec.cni.type is Not Calico")
+		}
+	}
 	return nil
 }
 

--- a/pkg/controller/installation/validation_test.go
+++ b/pkg/controller/installation/validation_test.go
@@ -485,19 +485,13 @@ var _ = Describe("Installation validation tests", func() {
 				Expect(fillDefaults(instance)).NotTo(HaveOccurred())
 				err := validateCustomResource(instance)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(*instance.Spec.Logging.CNILogging.LogFileMaxAgeDays).To(Equal(30))
+				Expect(*instance.Spec.Logging.CNILogging.LogFileMaxAgeDays).To(Equal(uint32(30)))
 			})
 			It("with invalid LogFileMaxAgeDays", func() {
-				instance.Spec.Logging.CNILogging.LogFileMaxAgeDays = new(int)
-				*instance.Spec.Logging.CNILogging.LogFileMaxAgeDays = -1
-				Expect(fillDefaults(instance)).NotTo(HaveOccurred())
-				err := validateCustomResource(instance)
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError("spec.Logging.cniLogging.logFileMaxAgeDays should be a positive non-zero integer"))
-
+				instance.Spec.Logging.CNILogging.LogFileMaxAgeDays = new(uint32)
 				*instance.Spec.Logging.CNILogging.LogFileMaxAgeDays = 0
 				Expect(fillDefaults(instance)).NotTo(HaveOccurred())
-				err = validateCustomResource(instance)
+				err := validateCustomResource(instance)
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError("spec.Logging.cniLogging.logFileMaxAgeDays should be a positive non-zero integer"))
 			})
@@ -505,19 +499,13 @@ var _ = Describe("Installation validation tests", func() {
 				Expect(fillDefaults(instance)).NotTo(HaveOccurred())
 				err := validateCustomResource(instance)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(*instance.Spec.Logging.CNILogging.LogFileMaxCount).To(Equal(10))
+				Expect(*instance.Spec.Logging.CNILogging.LogFileMaxCount).To(Equal(uint32(10)))
 			})
 			It("with invalid LogFileMaxCount", func() {
-				instance.Spec.Logging.CNILogging.LogFileMaxCount = new(int)
-				*instance.Spec.Logging.CNILogging.LogFileMaxCount = -1
-				Expect(fillDefaults(instance)).NotTo(HaveOccurred())
-				err := validateCustomResource(instance)
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError("spec.loggingConfig.cniLoggingConfig.logFileMaxCount value should be greater than zero"))
-
+				instance.Spec.Logging.CNILogging.LogFileMaxCount = new(uint32)
 				*instance.Spec.Logging.CNILogging.LogFileMaxCount = 0
 				Expect(fillDefaults(instance)).NotTo(HaveOccurred())
-				err = validateCustomResource(instance)
+				err := validateCustomResource(instance)
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError("spec.loggingConfig.cniLoggingConfig.logFileMaxCount value should be greater than zero"))
 			})

--- a/pkg/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/crds/operator/operator.tigera.io_installations.yaml
@@ -5468,17 +5468,19 @@ spec:
                   cniLogging:
                     description: Customized logging specification for calico-cni plugin
                     properties:
-                      logFileMaxAge:
-                        description: 'Default: 30 d'
-                        type: string
+                      logFileMaxAgeDays:
+                        description: 'Default: 30 (days)'
+                        format: int32
+                        type: integer
                       logFileMaxCount:
                         description: 'Default: 10'
+                        format: int32
                         type: integer
                       logFileMaxSize:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Default: 100 m'
+                        description: 'Default: 100Mi'
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       logSeverity:
@@ -13208,17 +13210,19 @@ spec:
                         description: Customized logging specification for calico-cni
                           plugin
                         properties:
-                          logFileMaxAge:
-                            description: 'Default: 30 d'
-                            type: string
+                          logFileMaxAgeDays:
+                            description: 'Default: 30 (days)'
+                            format: int32
+                            type: integer
                           logFileMaxCount:
                             description: 'Default: 10'
+                            format: int32
                             type: integer
                           logFileMaxSize:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: 'Default: 100 m'
+                            description: 'Default: 100Mi'
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
                           logSeverity:

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -54,8 +54,8 @@ var (
 	bgpDisabled          = operatorv1.BGPDisabled
 	nonPrivilegedEnabled = operatorv1.NonPrivilegedEnabled
 	logSeverity          = operatorv1.LogLevelDebug
-	logFileMaxAgeDays    = 5
-	logFileMaxCount      = 5
+	logFileMaxAgeDays    = uint32(5)
+	logFileMaxCount      = uint32(5)
 	logFileMaxSize       = resource.MustParse("1Mi")
 )
 

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -138,8 +138,8 @@ var _ = Describe("Rendering tests", func() {
 	var internalManagerKeyPair certificatemanagement.KeyPairInterface
 	var logSeverity = operatorv1.LogLevelInfo
 	var logFileMaxSize = resource.MustParse("100Mi")
-	var logFileMaxAgeDays = 30
-	var logFileMaxCount = 10
+	var logFileMaxAgeDays uint32 = 30
+	var logFileMaxCount uint32 = 10
 	one := intstr.FromInt(1)
 	miMode := operatorv1.MultiInterfaceModeNone
 	k8sServiceEp := k8sapi.ServiceEndpoint{}


### PR DESCRIPTION
This change is exposing a new logging property in the installation object. With this change users are able to provide customized logging configuration for calico cni plugin via tigera-operator.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
